### PR TITLE
Disabled the -fvisibility on benchmark for duo-GTest runner.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ option(BENCHMARK_USE_BUNDLED_GTEST "Use bundled GoogleTest. If disabled, the fin
 option(BENCHMARK_ENABLE_LIBPFM "Enable performance counters provided by libpfm" OFF)
 
 # Export only public symbols
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+#set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+#set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 if(MSVC)
     # As of CMake 3.18, CMAKE_SYSTEM_PROCESSOR is not set properly for MSVC and


### PR DESCRIPTION
With this setting a test runner that uses both Google Test and Google Benchmark on Mac was getting the following warning:
<img width="1792" alt="Screen Shot 2022-06-22 at 8 43 35 AM" src="https://user-images.githubusercontent.com/3475163/175097796-bc63933c-26c4-4601-9130-cf9652223aca.png">

With these changes that warning goes away:
<img width="1792" alt="Screen Shot 2022-06-22 at 1 13 00 PM" src="https://user-images.githubusercontent.com/3475163/175097867-3de218fb-d211-498d-a7f3-400a34bc4341.png">

Hope that helps! :smiley:
