### PR TITLE
Bug fix variable 'actual_iterations' set but not used (#1517)

### DIFF
--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -67,8 +67,8 @@ void BM_explicit_iteration_count(benchmark::State& state) {
 
   // Test that the requested iteration count is respected.
   assert(state.max_iterations == 42);
-  size_t actual_iterations = 0;
-  for (auto _ : state) ++actual_iterations;
+  for (auto _ : state) {
+  }
   assert(state.iterations() == state.max_iterations);
   assert(state.iterations() == 42);
 }


### PR DESCRIPTION
# Description
Pick bug fix from upstream repo for the this error we keep getting when compiling all of CommonCpp on Mac.

Upstream commit: https://github.com/google/benchmark/commit/62edc4fb00e1aeab86cc69c70eafffb17219d047

### Error
```
/Volumes/BuildDisk/Azure/_work/6/s/ThirdParty/benchmark/test/options_test.cc:70:10: error: variable 'actual_iterations' set but not used [-Werror,-Wunused-but-set-variable]
  size_t actual_iterations = 0;
         ^
1 error generated.
```

### Original description from upstream commit
```
* Bug fix variable 'actual_iterations' set but not used

Compiling the project in clang 15 without -Wno-unused-but-set-variable flag the following error is generated:

benchmark-src/test/options_test.cc:70:10: error: variable 'actual_iterations' set but not used [-Werror,-Wunused-but-set-variable]
  size_t actual_iterations = 0;
         ^

* Adjust according formatting of `clang-format`
```